### PR TITLE
Test against Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ python:
 env:
   - DJANGO_VERSION='>=1.8,<1.9'
   - DJANGO_VERSION='>=1.9,<1.10'
+  - DJANGO_VERSION='>=1.10,<1.11'
+  - DJANGO_VERSION='>=1.11,<2.0'
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
@@ -37,7 +39,18 @@ matrix:
   exclude:
     - python: "3.5"
       env: DJANGO_VERSION='>=1.8,<1.9'
+
     - python: "3.2"
       env: DJANGO_VERSION='>=1.9,<1.10'
     - python: "3.3"
       env: DJANGO_VERSION='>=1.9,<1.10'
+
+    - python: "3.2"
+      env: DJANGO_VERSION='>=1.10,<1.11'
+    - python: "3.3"
+      env: DJANGO_VERSION='>=1.10,<1.11'
+
+    - python: "3.2"
+      env: DJANGO_VERSION='>=1.11,<2.0'
+    - python: "3.3"
+      env: DJANGO_VERSION='>=1.11,<2.0'

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Requirements
 ------------
 
 - Python 2.7, 3.2, 3.3, 3.4, 3.5
-- Django >= 1.8
+- Django 1.8, 1.9, 1.10, 1.11
 
 Contributions and pull requests for other Django and Python versions are welcome.
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ minversion=1.8.0
 envlist =
     py{27,33,34}-django18
     py{27,34,35}-django19
+    py{27,34,35}-django110
+    py{27,34,35}-django111
 
 
 [testenv]
@@ -18,5 +20,6 @@ commands = coverage run --source=testapp,compositefk manage.py test
 deps =
     coverage
     django18: django >=1.8,<1.9
-    django19: django >=1.9a1,<1.10
-
+    django19: django >=1.9,<1.10
+    django110: django >=1.10,<1.11
+    django111: django >=1.11,<2.0


### PR DESCRIPTION
Modify travis and tox config files to include Django from 1.8 to 1.11 (included)