### PR TITLE
Add equality check for CompositePart

### DIFF
--- a/compositefk/fields.py
+++ b/compositefk/fields.py
@@ -298,6 +298,9 @@ class CompositePart(object):
     def __repr__(self):
         return "%s(%r)" % (self.__class__.__name__, self.value)
 
+    def __eq__(self, other):
+        return repr(self) == repr(other)
+
     def get_lookup(self, main_field, for_remote, alias):
         """
         create a fake field for the lookup capability

--- a/compositefk/fields.py
+++ b/compositefk/fields.py
@@ -299,7 +299,9 @@ class CompositePart(object):
         return "%s(%r)" % (self.__class__.__name__, self.value)
 
     def __eq__(self, other):
-        return repr(self) == repr(other)
+        if self.__class__ != other.__class__:
+            return False
+        return self.value == other.value
 
     def get_lookup(self, main_field, for_remote, alias):
         """


### PR DESCRIPTION
Addresses #6 

`makemigrations` is detecting that a `CompositeForeignKey` field is altered every time the script runs. The root cause was a failed equality check in `to_fields`, because the old and new `LocalFieldValue` were not equal. By adding an `__eq__` method to `CompositePart`, the equality check in `makemigrations` passes, and no new migration is generated.