### PR TITLE
Update README for Django 2.0 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Requirements
 ------------
 
 - Python 2.7, 3.2, 3.3, 3.4, 3.5
-- Django 1.8, 1.9, 1.10, 1.11
+- Django 1.8, 1.9, 1.10, 1.11, 2.0
 
 Contributions and pull requests for other Django and Python versions are welcome.
 


### PR DESCRIPTION
This PR bumped the version of `django-composite-foreignkey` to `1.0.1`, and has also added support for Django 2.0. So the `README.rst` file should be accordingly updated.