### PR TITLE
Drop EOL django versions and add support for Django 2.1 and Python 3.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,73 +1,60 @@
 # We do not use sudo
 sudo: false
 
-# Python versions for matrix
 language: python
-python:
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+cache:
+  pip: true
+  directories:
+  - $TRAVIS_BUILD_DIR/.tox
 
-# Django versions for matrix
-env:
-  - DJANGO_VERSION='>=1.8,<1.9'
-  - DJANGO_VERSION='>=1.9,<1.10'
-  - DJANGO_VERSION='>=1.10,<1.11'
-  - DJANGO_VERSION='>=1.11,<2.0'
-  - DJANGO_VERSION='>=2.0,<2.1'
+matrix:
+  fast_finish: true
+  include:
+  - env: TOX_ENV=py27-dj111
+    python: 2.7
+  - env: TOX_ENV=py34-dj111
+    python: 3.4
+  - env: TOX_ENV=py35-dj111
+    python: 3.5
+  - env: TOX_ENV=py36-dj111
+    python: 3.6
+  - env: TOX_ENV=py34-dj20
+    python: 3.4
+  - env: TOX_ENV=py35-dj20
+    python: 3.5
+  - env: TOX_ENV=py36-dj20
+    python: 3.6
+  - env: TOX_ENV=py37-dj20
+    sudo: true
+    dist: xenial
+    python: 3.7
+  - env: TOX_ENV=py35-dj21
+    python: 3.5
+  - env: TOX_ENV=py36-dj21
+    python: 3.6
+  - env: TOX_ENV=py37-dj21
+    sudo: true
+    dist: xenial
+    python: 3.7
+  - env: TOX_ENV=py35-djmaster
+    python: 3.5
+  - env: TOX_ENV=py36-djmaster
+    python: 3.6
+  - env: TOX_ENV=py37-djmaster
+    sudo: true
+    dist: xenial
+    python: 3.7
+  - env: TOX_ENV=flake8
+    python: 3.6
+  allow_failures:
+  - env: TOX_ENV=py35-djmaster
+  - env: TOX_ENV=py36-djmaster
+  - env: TOX_ENV=py37-djmaster
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install -q Django$DJANGO_VERSION --quiet
-  - pip install  python-coveralls
-  # virtualenv>=14.0.0 has dropped Python 3.2 support
-  - travis_retry pip install "virtualenv<14.0.0" "tox>=1.9"
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install 'coverage<4.0'; fi
-
+  - pip install -q -U tox
 
 # Command to run tests, e.g. python setup.py test
 script:
-  - coverage run --source=testapp,compositefk manage.py test
-
-
-# Report to coveralls
-after_success:
-  - coveralls
-
-matrix:
-  exclude:
-    - python: "2.7"
-      env: DJANGO_VERSION='>=2.0,<2.1'
-
-    - python: "3.6"
-      env: DJANGO_VERSION='>=1.8,<1.9'
-    - python: "3.6"
-      env: DJANGO_VERSION='>=1.9,<1.10'
-    - python: "3.6"
-      env: DJANGO_VERSION='>=1.10,<1.11'
-
-    - python: "3.5"
-      env: DJANGO_VERSION='>=1.8,<1.9'
-
-    - python: "3.2"
-      env: DJANGO_VERSION='>=1.9,<1.10'
-    - python: "3.3"
-      env: DJANGO_VERSION='>=1.9,<1.10'
-
-    - python: "3.2"
-      env: DJANGO_VERSION='>=1.10,<1.11'
-    - python: "3.3"
-      env: DJANGO_VERSION='>=1.10,<1.11'
-
-    - python: "3.2"
-      env: DJANGO_VERSION='>=1.11,<2.0'
-    - python: "3.3"
-      env: DJANGO_VERSION='>=1.11,<2.0'
-
-    - python: "3.2"
-      env: DJANGO_VERSION='>=2.0,<2.1'
-    - python: "3.3"
-      env: DJANGO_VERSION='>=2.0,<2.1'
+- tox -e "${TOX_ENV}"

--- a/README.rst
+++ b/README.rst
@@ -94,8 +94,8 @@ The full documentation is at http://django-composite-foreignkey.readthedocs.org/
 Requirements
 ------------
 
-- Python 2.7, 3.2, 3.3, 3.4, 3.5
-- Django 1.8, 1.9, 1.10, 1.11, 2.0
+- Python 2.7, 3.4, 3.5, 3.6, 3.7
+- Django 1.11, 2.0, 2.1
 
 Contributions and pull requests for other Django and Python versions are welcome.
 

--- a/broken_test_app/models.py
+++ b/broken_test_app/models.py
@@ -14,6 +14,7 @@ from django.db.models.deletion import CASCADE
 from compositefk.fields import CompositeForeignKey, RawFieldValue
 from testapp.models import Address
 
+
 logger = logging.getLogger(__name__)
 __author__ = 'darius.bernard'
 
@@ -28,9 +29,9 @@ class TempModel(models.Model):
         ("don'texists", 37),
     ])
 
+
 class BadModelsFieldsOrder(models.Model):
     company = models.IntegerField()
-
 
     address = CompositeForeignKey(Address, on_delete=CASCADE, null=True, to_fields=OrderedDict([
         ("company", "company"),
@@ -42,10 +43,10 @@ class BadModelsFieldsOrder(models.Model):
     # set up by the address field
     customer_id = models.IntegerField()
 
+
 class BadIdeaModel(models.Model):
     n = models.CharField(max_length=2)
     address = CompositeForeignKey(Address, on_delete=CASCADE, null=False, to_fields={
         "tiers_id": "n",
-        "company": "address",# recursive dependency
+        "company": "address",  # recursive dependency
     })
-

--- a/compositefk/compat.py
+++ b/compositefk/compat.py
@@ -1,13 +1,6 @@
 import django
 
 
-def get_remote_field(field):
-    if django.VERSION < (1, 9):
-        return field.rel
-    else:
-        return field.remote_field
-
-
 def get_cached_value(instance, descriptor, default=None):
     if django.VERSION < (2, 0):
         return getattr(instance, descriptor.cache_name, default)

--- a/compositefk/fields.py
+++ b/compositefk/fields.py
@@ -10,16 +10,12 @@ from functools import wraps
 from django.core import checks
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models.fields.related import ForeignObject
+from django.db.models.fields.related_descriptors import ReverseOneToOneDescriptor
 from django.db.models.sql.where import WhereNode, AND
+from django.utils.translation import ugettext_lazy as _
 
 from compositefk.related_descriptors import CompositeForwardManyToOneDescriptor
 
-try:
-    from django.db.models.fields.related_descriptors import ReverseOneToOneDescriptor
-except ImportError:
-    from django.db.models.fields.related import SingleRelatedObjectDescriptor as ReverseOneToOneDescriptor
-
-from django.utils.translation import ugettext_lazy as _
 
 logger = logging.getLogger(__name__)
 __author__ = 'darius.bernard'

--- a/compositefk/fields.py
+++ b/compositefk/fields.py
@@ -9,7 +9,6 @@ from functools import wraps
 
 from django.core import checks
 from django.core.exceptions import FieldDoesNotExist
-from django.db.models.fields import Field
 from django.db.models.fields.related import ForeignObject
 from django.db.models.sql.where import WhereNode, AND
 
@@ -85,7 +84,7 @@ class CompositeForeignKey(ForeignObject):
         try:
             dependents = list(self.local_related_fields)
         except FieldDoesNotExist:
-            return [] # the errors shall be raised befor by _check_recursion_field_dependecy
+            return []  # the errors shall be raised befor by _check_recursion_field_dependecy
 
         for field in self.model._meta.get_fields():
             try:
@@ -117,7 +116,8 @@ class CompositeForeignKey(ForeignObject):
                 if isinstance(f, CompositeForeignKey):
                     res.append(
                         checks.Error(
-                            "the field %s depend on the field %s which is another CompositeForeignKey" % (self.name, local_field),
+                            "the field %s depend on the field %s which is another CompositeForeignKey" %
+                            (self.name, local_field),
                             hint=None,
                             obj=self,
                             id='compositefk.E005',
@@ -164,7 +164,8 @@ class CompositeForeignKey(ForeignObject):
         if self.null_if_equal and not self.null:
             return [
                 checks.Error(
-                    "you must set null=True to field %s.%s if null_if_equal is given" % (self.model.__class__.__name__, self.name),
+                    "you must set null=True to field %s.%s if null_if_equal is given" %
+                    (self.model.__class__.__name__, self.name),
                     hint=None,
                     obj=self,
                     id='compositefk.E001',
@@ -201,7 +202,7 @@ class CompositeForeignKey(ForeignObject):
         return {
             k: v.value for k, v in self._raw_fields.items()
             if isinstance(v, RawFieldValue)
-            }
+        }
 
     def get_extra_restriction(self, where_class, alias, related_alias):
         constraint = WhereNode(connector=AND)
@@ -250,12 +251,13 @@ class CompositeForeignKey(ForeignObject):
         # '   ' into a true None to let django das as if it was None
         res = super(CompositeForeignKey, self).get_instance_value_for_fields(instance, fields)
         if self.null_if_equal:
-            cur_values_dict = dict(zip((f.name for f in fields), res))
             for field_name, exception_value in self.null_if_equal:
                 val = getattr(instance, field_name)
                 if val == exception_value:
                     # we have field_name that is equal to the bad value
-                    return (None,)  # currently, it is enouth since the django implementation check at first if there is a None in the result
+                    # currently, it is enouth since the django implementation check at first
+                    # if there is a None in the result
+                    return (None,)
         return res
 
 

--- a/compositefk/fields.py
+++ b/compositefk/fields.py
@@ -13,7 +13,6 @@ from django.db.models.fields import Field
 from django.db.models.fields.related import ForeignObject
 from django.db.models.sql.where import WhereNode, AND
 
-from compositefk.compat import get_remote_field
 from compositefk.related_descriptors import CompositeForwardManyToOneDescriptor
 
 try:
@@ -274,7 +273,7 @@ class CompositeOneToOneField(CompositeForeignKey):
     def __init__(self, to, **kwargs):
         kwargs['unique'] = True
         super(CompositeOneToOneField, self).__init__(to, **kwargs)
-        get_remote_field(self).multiple = False
+        self.remote_field.multiple = False
 
     def deconstruct(self):
         name, path, args, kwargs = super(CompositeOneToOneField, self).deconstruct()

--- a/compositefk/related_descriptors.py
+++ b/compositefk/related_descriptors.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals, print_function, absolute_import
 import logging
 
 from compositefk.compat import (
-    get_remote_field,
     set_cached_value_by_descriptor,
     set_cached_value_by_field,
     get_cached_value,
@@ -41,7 +40,7 @@ class CompositeForwardManyToOneDescriptor(ForwardManyToOneDescriptor):
             # cache. This cache also might not exist if the related object
             # hasn't been accessed yet.
             if related is not None:
-                related_field = get_remote_field(self.field)
+                related_field = self.field.remote_field
                 set_cached_value_by_field(related, related_field, None)
 
             # ##### only original part

--- a/compositefk/related_descriptors.py
+++ b/compositefk/related_descriptors.py
@@ -5,16 +5,14 @@
 from __future__ import unicode_literals, print_function, absolute_import
 import logging
 
+from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor
+
 from compositefk.compat import (
     set_cached_value_by_descriptor,
     set_cached_value_by_field,
     get_cached_value,
 )
 
-try:
-    from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor
-except ImportError:
-    from django.db.models.fields.related import ReverseSingleRelatedObjectDescriptor as ForwardManyToOneDescriptor
 
 logger = logging.getLogger(__name__)
 __author__ = 'darius.bernard'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 description-file = README.rst
+
 [bdist_wheel]
 universal = 1
 
@@ -7,3 +8,14 @@ universal = 1
 omit =
   docs
   testapp/management
+
+[flake8]
+max-line-length = 119
+exclude =
+    .eggs,
+    .cache,
+    .git,
+    .tox,
+    docs,
+    migrations,
+    __pycache__

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 
@@ -51,15 +48,16 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Operating System :: OS Independent',
         'Topic :: Software Development :: Libraries',
         'Topic :: Utilities',
         'Environment :: Web Environment',
-        'Framework :: Django',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
     ],
 )

--- a/testapp/management/commands/graph_datas.py
+++ b/testapp/management/commands/graph_datas.py
@@ -7,6 +7,7 @@ from django.core.management.base import BaseCommand, CommandError
 def get_name(obj):
     return "%s_%s" % (obj._meta.model_name, obj.pk)
 
+
 class Command(BaseCommand):
     help = (
         "verry simple command that will output a dot diagraph "
@@ -31,10 +32,12 @@ class Command(BaseCommand):
         #
 
         def node_generator():
-            for app_config in app_configs: # type: django.apps.config.AppConfig
-                for model in app_config.get_models(): # type: django.db.models.Model
+            for app_config in app_configs:  # type: django.apps.config.AppConfig
+                for model in app_config.get_models():  # type: django.db.models.Model
                     if model.objects.count() > 100:
-                        raise CommandError("to many items in the model %s to be effective. this commande is a bad idea on your app")
+                        raise CommandError(
+                            "to many items in the model %s to be effective. this commande is a bad idea on your app"
+                        )
                     for obj in model.objects.all():
                         childs = []
                         for field in model._meta.get_fields():
@@ -51,10 +54,9 @@ class Command(BaseCommand):
 
         self.stdout.write(self.get_digraph(node_generator()))
 
-
     def get_digraph(self, objects):
         edges = []
-        nodes=OrderedDict()
+        nodes = OrderedDict()
         for obj, childs in objects:
             nodes.setdefault(obj.__class__, []).append(obj)
             edges.append(get_name(obj))
@@ -62,9 +64,8 @@ class Command(BaseCommand):
                 edges.append("%s  -> %s" % (get_name(obj), get_name(child)))
         return "digraph items_in_db {\n%s\n%s;\n}" % (
             "\n".join(
-                ("{ rank=same; %s; }"% ";".join(map(get_name, objs)))
+                ("{ rank=same; %s; }" % ";".join(map(get_name, objs)))
                 for objs in nodes.values()
             ),
             ";\n".join(edges)
         )
-

--- a/testapp/models.py
+++ b/testapp/models.py
@@ -7,8 +7,10 @@ from __future__ import unicode_literals, print_function, absolute_import
 import logging
 from collections import OrderedDict
 
-import django.db.models as models
+from django.db import models
 from django.db.models.deletion import CASCADE, DO_NOTHING
+from django.conf import global_settings
+from django.utils.translation import get_language
 
 from compositefk.fields import (
     CompositeForeignKey,
@@ -119,7 +121,6 @@ class Contact(models.Model):
     ]))
 
 
-
 class PhoneNumber(models.Model):
     num = models.CharField(max_length=32)
     type_number = models.IntegerField()
@@ -147,10 +148,6 @@ class AModel(models.Model):
 
 class BModel(models.Model):
     a = models.ForeignKey(AModel, null=True, on_delete=CASCADE)
-
-
-from django.conf import global_settings
-from django.utils.translation import get_language
 
 
 class MultiLangSupplier(models.Model):

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -25,19 +25,11 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.db.migrations.autodetector import MigrationAutodetector
 from django.db.migrations.loader import MigrationLoader
-
-try:
-    from django.db.migrations.questioner import NonInteractiveMigrationQuestioner
-except ImportError:
-    from django.db.migrations.questioner import MigrationQuestioner as NonInteractiveMigrationQuestioner
+from django.db.migrations.questioner import NonInteractiveMigrationQuestioner
 from django.core import checks
 from django.db.migrations.state import ProjectState
 from django.db.migrations.writer import MigrationWriter
-try:
-    from django.db.models.fields.reverse_related import ForeignObjectRel
-except ImportError:
-    from django.db.models.fields.related import ForeignObjectRel
-
+from django.db.models.fields.reverse_related import ForeignObjectRel
 from django.test.testcases import TestCase
 from compositefk.fields import CompositeForeignKey, RawFieldValue, FunctionBasedFieldValue
 from testapp.models import (

--- a/tox.ini
+++ b/tox.ini
@@ -5,24 +5,35 @@
 [flake8]
 max-line-length=119
 
-
 [tox]
 minversion=1.8.0
 envlist =
-    py{27,33,34}-django18
-    py{27,34,35}-django19
-    py{27,34,35}-django110
-    py{27,34,35,36}-django111
-    py{34,35,36}-django20
-
+    py{27,34,35,36}-dj111,
+    py{34,35,36,37}-dj20,
+    py{35,36,37}-dj21,
+    flake8
 
 [testenv]
-commands = coverage run --source=testapp,compositefk manage.py test
+basepython =
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
+    py37: python3.7
 deps =
     coverage
-    mock
-    django18: django >=1.8,<1.9
-    django19: django >=1.9,<1.10
-    django110: django >=1.10,<1.11
-    django111: django >=1.11,<2.0
-    django20: django >=2.0,<2.1
+    py27: mock
+    py37-dj21: codecov
+    dj111: django >=1.11,<2.0
+    dj20: django >=2.0,<2.1
+    dj21: django >=2.1,<2.2
+    djmaster: https://github.com/django/django/archive/master.tar.gz
+commands =
+    coverage run --source=testapp,compositefk manage.py test
+    py37-dj21: codecov
+
+[testenv:flake8]
+skip_install = true
+basepython = python3
+deps = flake8
+commands = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,6 @@
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
-[flake8]
-max-line-length=119
-
 [tox]
 minversion=1.8.0
 envlist =


### PR DESCRIPTION
- Drop supports for EOL versions (See: <https://www.djangoproject.com/download/>)
    - Django 1.8
    - Django 1.9
    - Django 1.10
- Add support
    - Django 2.1
    - Python 3.7 (See: <https://docs.djangoproject.com/en/2.1/faq/install/#what-python-version-can-i-use-with-django>)
- Migrate (and cache dependencies) to tox. Env matrix is too complex :(