### PR TITLE
removed translation function for the description of CompositeOneToOneField

### DIFF
--- a/compositefk/fields.py
+++ b/compositefk/fields.py
@@ -12,7 +12,6 @@ from django.core.exceptions import FieldDoesNotExist
 from django.db.models.fields.related import ForeignObject
 from django.db.models.fields.related_descriptors import ReverseOneToOneDescriptor
 from django.db.models.sql.where import WhereNode, AND
-from django.utils.translation import ugettext_lazy as _
 
 from compositefk.related_descriptors import CompositeForwardManyToOneDescriptor
 
@@ -266,7 +265,7 @@ class CompositeOneToOneField(CompositeForeignKey):
 
     related_accessor_class = ReverseOneToOneDescriptor
 
-    description = _("One-to-one relationship")
+    description = "One-to-one relationship"
 
     def __init__(self, to, **kwargs):
         kwargs['unique'] = True


### PR DESCRIPTION
Importing in a Django 4.0.1 results in error 
```
ImportError: cannot import name 'ugettext_lazy' from 'django.utils.translation' (/venv/lib/python3.9/sitepackages/django/utils/translation/__init__.py)
```

[ugettext_lazy has been removed in Django 4.0.0](https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0). Instead of updating to the new alias, gettext_lazy, I removed it because translation is not used elsewhere in the project.